### PR TITLE
Add AMD build

### DIFF
--- a/steps/kernel_density_estimation_cpp/CMakeLists.txt
+++ b/steps/kernel_density_estimation_cpp/CMakeLists.txt
@@ -6,7 +6,13 @@ project(kde_app
     DESCRIPTION "C++ SYCL sample application to compute Kernel Density Estimation"
 )
 
-option(TARGET_CUDA "Whether to build SYCL target NVPTX64 in addition to default SPIR64 SYCL target" OFF)
+option(TARGET_CUDA "Whether to additionally target NVPTX64" OFF)
+
+set(TARGET_HIP
+    ""
+    CACHE STRING
+    "Whether to additionally target a user-specified HIP architecture"
+)
 
 find_package(IntelSYCL REQUIRED)
 
@@ -18,9 +24,33 @@ target_include_directories(kde_app PUBLIC ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR
 add_sycl_to_target(TARGET kde_app SOURCES ${CMAKE_SOURCE_DIR}/app.cpp)
 target_compile_options(kde_app PUBLIC -Wall)
 
+set(_sycl_targets)
+set(_hip_targets)
 if (${TARGET_CUDA})
-    target_compile_options(kde_app PUBLIC -fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown)
-    target_link_options(kde_app PUBLIC -fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown)
+    set(_sycl_targets "nvptx64-nvidia-cuda,spir64-unknown-unknown")
+endif()
+if (NOT "x${TARGET_HIP}" STREQUAL "x")
+    set(_hip_targets ${TARGET_HIP})
+    if(_sycl_targets)
+        set(_sycl_targets "amdgcn-amd-amdhsa,${_dpctl_sycl_targets}")
+    else()
+        set(_sycl_targets "amdgcn-amd-amdhsa,spir64-unknown-unknown")
+    endif()
+endif()
+
+set(_sycl_target_compile_options)
+set(_sycl_target_link_options)
+
+if (_sycl_targets)
+    message(STATUS "Compiling for -fsycl-targets=${_sycl_targets}")
+    list(APPEND _sycl_target_compile_options -fsycl-targets=${_sycl_targets})
+    list(APPEND _sycl_target_link_options -fsycl-targets=${_sycl_targets})
+    if(_hip_targets)
+        list(APPEND _sycl_target_compile_options -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=${_hip_targets})
+        list(APPEND _sycl_target_link_options -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=${_hip_targets})
+    endif()
+    target_compile_options(kde_app PUBLIC ${_sycl_target_compile_options})
+    target_link_options(kde_app PUBLIC ${_sycl_target_link_options})
 endif()
 
 install(TARGETS kde_app DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/steps/kernel_density_estimation_cpp/building.md
+++ b/steps/kernel_density_estimation_cpp/building.md
@@ -12,7 +12,20 @@ $ type -P icpx || source /opt/intel/oneapi/setvars.sh
 $ CXX=icpx cmake . -B cmake_build_dir -DCMAKE_INSTALL_PREFIX=cmake_install_dir
 ```
 
-Use `-DTARGET_CUDA=ON` to build multi-target binary.
+Use `-DTARGET_CUDA=ON` to build multi-target binary for CUDA.
+
+For HIP, use `-DTARGET_HIP=<ARCH>` where `<ARCH>` is the architecture of the AMD GPU.
+
+To find the architecture, use
+```bash
+rocminfo | grep 'Name: *gfx.*'
+```
+
+which should show something like
+```bash
+  Name:                    gfx1030
+```
+where `gfx` followed by four digits the GPU's the architecture.
 
 4. Build and install
 The C++ code uses [argparse](https://github.com/p-ranav/argparse) project to support CLI options. 
@@ -38,7 +51,20 @@ $ type -P icpx || source /opt/intel/oneapi/setvars.sh
 $ CXX=icpx meson setup meson_build_dir
 ```
 
-Use `-Dtarget-cuda=true` to build multi-target binary.
+Use `-Dtarget-cuda=true` to build multi-target binary for CUDA.
+
+For HIP, use `-DTARGET_HIP=<ARCH>` where `<ARCH>` is the architecture of the AMD GPU.
+
+To find the architecture, use
+```bash
+rocminfo | grep 'Name: *gfx.*'
+```
+
+which should show something like
+```bash
+  Name:                    gfx1030
+```
+where `gfx` followed by four digits the GPU's the architecture.
 
 4. Build and install
 ```bash

--- a/steps/kernel_density_estimation_cpp/meson.build
+++ b/steps/kernel_density_estimation_cpp/meson.build
@@ -1,4 +1,4 @@
-project('kde_app', 'cpp')
+project('kde_app', 'cpp', default_options: ['buildtype=release'])
 
 sycl_feature_code = '''#include <iostream>
 using namespace std;

--- a/steps/kernel_density_estimation_cpp/meson.build
+++ b/steps/kernel_density_estimation_cpp/meson.build
@@ -19,19 +19,23 @@ endif
 should_target_cuda = get_option('target-cuda')
 targeted_hip_arch = get_option('target-hip')
 if should_target_cuda
-    sycl_targets = 'nvptx64-nvidia-cuda,spir64-unknown-unknown'
+  sycl_targets = 'nvptx64-nvidia-cuda,spir64-unknown-unknown'
+endif
 if targeted_hip_arch != ''
-    if sycl_targets
-        sycl_targets = 'amdgcn-amd-amdhsa,' + sycl_targets
-    else
-        sycl_targets = 'amdgcn-amd-amdhsa,spir64-unknown-unknown'
+  if sycl_targets
+    sycl_targets = 'amdgcn-amd-amdhsa,' + sycl_targets
+  else
+    sycl_targets = 'amdgcn-amd-amdhsa,spir64-unknown-unknown'
+  endif
+endif
 
 if sycl_targets != ''
-    sycl_compile_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
-    sycl_link_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
-    if targeted_hip_arch != ''
-        sycl_compile_opts = sycl_compile_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
-        sycl_link_opts = sycl_link_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
+  sycl_compile_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
+  sycl_link_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
+  if targeted_hip_arch != ''
+    sycl_compile_opts = sycl_compile_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
+    sycl_link_opts = sycl_link_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
+  endif
 else
     sycl_compile_opts = '-fsycl'
     sycl_link_opts = '-fsycl'

--- a/steps/kernel_density_estimation_cpp/meson.build
+++ b/steps/kernel_density_estimation_cpp/meson.build
@@ -17,9 +17,20 @@ if not result
 endif
 
 should_target_cuda = get_option('target-cuda')
+targeted_hip_arch = get_option('target-hip')
 if should_target_cuda
-    sycl_compile_opts = ['-fsycl', '-fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown']
-    sycl_link_opts = ['-fsycl', '-fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown']
+    sycl_targets = 'nvptx64-nvidia-cuda,spir64-unknown-unknown'
+if targeted_hip_arch
+    if sycl_targets
+      sycl_targets = 'amdgcn-amd-amdhsa,' + sycl_targets
+    else
+      sycl_targets = 'amdgcn-amd-amdhsa,spir64-unknown-unknown'
+if sycl_targets
+  sycl_compile_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
+  sycl_link_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
+  if targeted_hip_arch
+    sycl_compile_opts = sycl_compile_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
+    sycl_link_opts = sycl_link_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
 else
     sycl_compile_opts = '-fsycl'
     sycl_link_opts = '-fsycl'

--- a/steps/kernel_density_estimation_cpp/meson.build
+++ b/steps/kernel_density_estimation_cpp/meson.build
@@ -22,7 +22,7 @@ if should_target_cuda
   sycl_targets = 'nvptx64-nvidia-cuda,spir64-unknown-unknown'
 endif
 if targeted_hip_arch != ''
-  if sycl_targets
+  if sycl_targets != ''
     sycl_targets = 'amdgcn-amd-amdhsa,' + sycl_targets
   else
     sycl_targets = 'amdgcn-amd-amdhsa,spir64-unknown-unknown'

--- a/steps/kernel_density_estimation_cpp/meson.build
+++ b/steps/kernel_density_estimation_cpp/meson.build
@@ -18,6 +18,7 @@ endif
 
 should_target_cuda = get_option('target-cuda')
 targeted_hip_arch = get_option('target-hip')
+sycl_targets = ''
 if should_target_cuda
   sycl_targets = 'nvptx64-nvidia-cuda,spir64-unknown-unknown'
 endif

--- a/steps/kernel_density_estimation_cpp/meson.build
+++ b/steps/kernel_density_estimation_cpp/meson.build
@@ -20,17 +20,18 @@ should_target_cuda = get_option('target-cuda')
 targeted_hip_arch = get_option('target-hip')
 if should_target_cuda
     sycl_targets = 'nvptx64-nvidia-cuda,spir64-unknown-unknown'
-if targeted_hip_arch
+if targeted_hip_arch != ''
     if sycl_targets
-      sycl_targets = 'amdgcn-amd-amdhsa,' + sycl_targets
+        sycl_targets = 'amdgcn-amd-amdhsa,' + sycl_targets
     else
-      sycl_targets = 'amdgcn-amd-amdhsa,spir64-unknown-unknown'
-if sycl_targets
-  sycl_compile_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
-  sycl_link_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
-  if targeted_hip_arch
-    sycl_compile_opts = sycl_compile_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
-    sycl_link_opts = sycl_link_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
+        sycl_targets = 'amdgcn-amd-amdhsa,spir64-unknown-unknown'
+
+if sycl_targets != ''
+    sycl_compile_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
+    sycl_link_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
+    if targeted_hip_arch != ''
+        sycl_compile_opts = sycl_compile_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
+        sycl_link_opts = sycl_link_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
 else
     sycl_compile_opts = '-fsycl'
     sycl_link_opts = '-fsycl'

--- a/steps/kernel_density_estimation_cpp/meson.options
+++ b/steps/kernel_density_estimation_cpp/meson.options
@@ -7,7 +7,7 @@ option(
 
 option(
     'target-hip',
-    type: 'str',
+    type: 'string',
     value: '',
     description: 'Whether to compile for a given HIP architecture'
 )

--- a/steps/kernel_density_estimation_cpp/meson.options
+++ b/steps/kernel_density_estimation_cpp/meson.options
@@ -4,3 +4,10 @@ option(
     value: false, 
     description: 'Whether to compile for SYCL target NVPTX64'
 )
+
+option(
+    'target-hip',
+    type: 'str',
+    value: '',
+    description: 'Whether to compile for a given HIP architecture'
+)

--- a/steps/mkl_interface/building.md
+++ b/steps/mkl_interface/building.md
@@ -122,11 +122,30 @@ git clone https://github.com/IntelPython/dpctl.git
 
 Make sure the necessary requirements are installed for your build path ([`scikit-build-core`](#building-c-extension-using-scikit-build-core) or [`meson-python`](#building-c-extension-using-meson-python) for each build path and installing the requirements). The appropriate requirements file will be named `requirements_build.txt` if building to target non-Intel devices, while the environment file will be `environment_build.yml`.
 
-Now build
+Now to build for CUDA
 
 ```bash
 python scripts/build_locally.py --verbose --cmake-opts="-DDPCTL_TARGET_CUDA=ON"
 ```
+
+For HIP, use
+
+```bash
+python scripts/build_locally.py --verbose --cmake-opts="-DDPCTL_TARGET_HIP=<ARCH>"
+```
+
+where `<ARCH>` is the architecture of the AMD GPU.
+
+To find the architecture, use
+```bash
+rocminfo | grep 'Name: *gfx.*'
+```
+
+which should show something like
+```bash
+  Name:                    gfx1030
+```
+where `gfx` followed by four digits the GPU's the architecture.
 
 See the [`dpctl` documentation](https://intelpython.github.io/dpctl/latest/beginners_guides/installation.html#building-for-custom-sycl-targets) for more information.
 
@@ -210,6 +229,17 @@ CXX=icpx pip install -e scikit_build_core_mkl_ext/ --no-deps --no-build-isolatio
     -Ccmake.args="-DTARGET_CUDA=ON"
 ```
 
+If building for AMD GPUs, add `-Ccmake.args="-DTARGET_HIP=<ARCH>"`:
+
+```bash
+CXX=icpx pip install -e scikit_build_core_mkl_ext/ --no-deps --no-build-isolation --verbose \
+    -Ccmake.args="-DTARGET_HIP=<ARCH>"
+```
+
+where `<ARCH>` is the GPU architecture. See [dpctl NVidia and AMD build instructions](#build-dpctl-for-nvidia-or-amd) for an example of
+finding the architecture.
+
+
 ### Building C++ extension using `meson-python`
 
 Make sure to delete the `mkl_interface_ext/_qr.so` if manual building was performed.
@@ -241,7 +271,17 @@ pytest tests
 
 If building for NVidia GPUs, add `-Csetup-args="-Dtarget-cuda=true"`:
 
-``bash
+```bash
 CXX=icpx pip install -e meson_mkl_ext/ --no-deps --no-build-isolation --verbose \
     -Csetup-args="-Dtarget-cuda=true"
 ```
+
+If building for AMD GPUs, add `-Csetup-args="-Dtarget-hip=<ARCH>"`:
+
+```bash
+CXX=icpx pip install -e meson_mkl_ext/ --no-deps --no-build-isolation --verbose \
+    -Csetup-args="-Dtarget-hip=<ARCH>"
+```
+
+where `<ARCH>` is the GPU architecture. See [dpctl NVidia and AMD build instructions](#build-dpctl-for-nvidia-or-amd) for an example of
+finding the architecture.

--- a/steps/mkl_interface/meson_mkl_ext/meson.build
+++ b/steps/mkl_interface/meson_mkl_ext/meson.build
@@ -26,7 +26,7 @@ if should_target_cuda
   sycl_targets = 'nvptx64-nvidia-cuda,spir64-unknown-unknown'
 endif
 if targeted_hip_arch != ''
-  if sycl_targets
+  if sycl_targets != ''
     sycl_targets = 'amdgcn-amd-amdhsa,' + sycl_targets
   else
     sycl_targets = 'amdgcn-amd-amdhsa,spir64-unknown-unknown'

--- a/steps/mkl_interface/meson_mkl_ext/meson.build
+++ b/steps/mkl_interface/meson_mkl_ext/meson.build
@@ -22,6 +22,7 @@ endif
 
 should_target_cuda = get_option('target-cuda')
 targeted_hip_arch = get_option('target-hip')
+sycl_targets = ''
 if should_target_cuda
   sycl_targets = 'nvptx64-nvidia-cuda,spir64-unknown-unknown'
 endif

--- a/steps/mkl_interface/meson_mkl_ext/meson.build
+++ b/steps/mkl_interface/meson_mkl_ext/meson.build
@@ -21,9 +21,20 @@ if not result
 endif
 
 should_target_cuda = get_option('target-cuda')
+targeted_hip_arch = get_option('target-hip')
 if should_target_cuda
-    sycl_compile_opts = ['-fsycl', '-fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown']
-    sycl_link_opts = ['-fsycl', '-fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown']
+    sycl_targets = 'nvptx64-nvidia-cuda,spir64-unknown-unknown'
+if targeted_hip_arch
+    if sycl_targets
+      sycl_targets = 'amdgcn-amd-amdhsa,' + sycl_targets
+    else
+      sycl_targets = 'amdgcn-amd-amdhsa,spir64-unknown-unknown'
+if sycl_targets
+  sycl_compile_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
+  sycl_link_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
+  if targeted_hip_arch
+    sycl_compile_opts = sycl_compile_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
+    sycl_link_opts = sycl_link_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
 else
     sycl_compile_opts = '-fsycl'
     sycl_link_opts = '-fsycl'

--- a/steps/mkl_interface/meson_mkl_ext/meson.build
+++ b/steps/mkl_interface/meson_mkl_ext/meson.build
@@ -24,17 +24,18 @@ should_target_cuda = get_option('target-cuda')
 targeted_hip_arch = get_option('target-hip')
 if should_target_cuda
     sycl_targets = 'nvptx64-nvidia-cuda,spir64-unknown-unknown'
-if targeted_hip_arch
+if targeted_hip_arch != ''
     if sycl_targets
-      sycl_targets = 'amdgcn-amd-amdhsa,' + sycl_targets
+        sycl_targets = 'amdgcn-amd-amdhsa,' + sycl_targets
     else
-      sycl_targets = 'amdgcn-amd-amdhsa,spir64-unknown-unknown'
-if sycl_targets
-  sycl_compile_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
-  sycl_link_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
-  if targeted_hip_arch
-    sycl_compile_opts = sycl_compile_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
-    sycl_link_opts = sycl_link_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
+        sycl_targets = 'amdgcn-amd-amdhsa,spir64-unknown-unknown'
+
+if sycl_targets != ''
+    sycl_compile_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
+    sycl_link_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
+    if targeted_hip_arch != ''
+        sycl_compile_opts = sycl_compile_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
+        sycl_link_opts = sycl_link_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
 else
     sycl_compile_opts = '-fsycl'
     sycl_link_opts = '-fsycl'

--- a/steps/mkl_interface/meson_mkl_ext/meson.build
+++ b/steps/mkl_interface/meson_mkl_ext/meson.build
@@ -23,19 +23,23 @@ endif
 should_target_cuda = get_option('target-cuda')
 targeted_hip_arch = get_option('target-hip')
 if should_target_cuda
-    sycl_targets = 'nvptx64-nvidia-cuda,spir64-unknown-unknown'
+  sycl_targets = 'nvptx64-nvidia-cuda,spir64-unknown-unknown'
+endif
 if targeted_hip_arch != ''
-    if sycl_targets
-        sycl_targets = 'amdgcn-amd-amdhsa,' + sycl_targets
-    else
-        sycl_targets = 'amdgcn-amd-amdhsa,spir64-unknown-unknown'
+  if sycl_targets
+    sycl_targets = 'amdgcn-amd-amdhsa,' + sycl_targets
+  else
+    sycl_targets = 'amdgcn-amd-amdhsa,spir64-unknown-unknown'
+  endif
+endif
 
 if sycl_targets != ''
-    sycl_compile_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
-    sycl_link_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
-    if targeted_hip_arch != ''
-        sycl_compile_opts = sycl_compile_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
-        sycl_link_opts = sycl_link_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
+  sycl_compile_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
+  sycl_link_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
+  if targeted_hip_arch != ''
+    sycl_compile_opts = sycl_compile_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
+    sycl_link_opts = sycl_link_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
+  endif
 else
     sycl_compile_opts = '-fsycl'
     sycl_link_opts = '-fsycl'

--- a/steps/mkl_interface/meson_mkl_ext/meson.options
+++ b/steps/mkl_interface/meson_mkl_ext/meson.options
@@ -7,7 +7,7 @@ option(
 
 option(
     'target-hip',
-    type: 'str',
+    type: 'string',
     value: '',
     description: 'Whether to compile for a given HIP architecture'
 )

--- a/steps/mkl_interface/meson_mkl_ext/meson.options
+++ b/steps/mkl_interface/meson_mkl_ext/meson.options
@@ -4,3 +4,10 @@ option(
     value: false, 
     description: 'Whether to compile for SYCL target NVPTX64'
 )
+
+option(
+    'target-hip',
+    type: 'str',
+    value: '',
+    description: 'Whether to compile for a given HIP architecture'
+)

--- a/steps/mkl_interface/scikit_build_core_mkl_ext/CMakeLists.txt
+++ b/steps/mkl_interface/scikit_build_core_mkl_ext/CMakeLists.txt
@@ -5,7 +5,14 @@ project(${SKBUILD_PROJECT_NAME}
     LANGUAGES CXX
     DESCRIPTION "A sample pybind11 extension using portable oneMKL interface library"
 )
-option(TARGET_CUDA "Whether to build SYCL target NVPTX64 in addition to default SPIR64 SYCL target" OFF)
+
+option(TARGET_CUDA "Whether to additionally target NVPTX64" OFF)
+
+set(TARGET_HIP
+    ""
+    CACHE STRING
+    "Whether to additionally target a user-specified HIP architecture"
+)
 
 find_package(IntelSYCL REQUIRED)
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
@@ -42,9 +49,33 @@ target_include_directories(${py_module_name} PRIVATE ${Dpctl_TENSOR_INCLUDE_DIR}
 
 target_link_libraries(${py_module_name} PRIVATE MKL::onemkl)
 
+set(_sycl_targets)
+set(_hip_targets)
 if (${TARGET_CUDA})
-    target_compile_options(${py_module_name} PRIVATE -fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown)
-    target_link_options(${py_module_name} PRIVATE -fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown)
+    set(_sycl_targets "nvptx64-nvidia-cuda,spir64-unknown-unknown")
+endif()
+if (NOT "x${TARGET_HIP}" STREQUAL "x")
+    set(_hip_targets ${TARGET_HIP})
+    if(_sycl_targets)
+        set(_sycl_targets "amdgcn-amd-amdhsa,${_dpctl_sycl_targets}")
+    else()
+        set(_sycl_targets "amdgcn-amd-amdhsa,spir64-unknown-unknown")
+    endif()
+endif()
+
+set(_sycl_target_compile_options)
+set(_sycl_target_link_options)
+
+if (_sycl_targets)
+    message(STATUS "Compiling for -fsycl-targets=${_sycl_targets}")
+    list(APPEND _sycl_target_compile_options -fsycl-targets=${_sycl_targets})
+    list(APPEND _sycl_target_link_options -fsycl-targets=${_sycl_targets})
+    if(_hip_targets)
+        list(APPEND _sycl_target_compile_options -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=${_hip_targets})
+        list(APPEND _sycl_target_link_options -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=${_hip_targets})
+    endif()
+    target_compile_options(${py_module_name} PUBLIC ${_sycl_target_compile_options})
+    target_link_options(${py_module_name} PUBLIC ${_sycl_target_link_options})
 endif()
 
 install(TARGETS ${py_module_name} DESTINATION ${SKBUILD_PROJECT_NAME})

--- a/steps/sycl_python_extension/building.md
+++ b/steps/sycl_python_extension/building.md
@@ -18,6 +18,25 @@ Now build
 python scripts/build_locally.py --verbose --cmake-opts="-DDPCTL_TARGET_CUDA=ON"
 ```
 
+For HIP, use
+
+```bash
+python scripts/build_locally.py --verbose --cmake-opts="-DDPCTL_TARGET_HIP=<ARCH>"
+```
+
+where `<ARCH>` is the architecture of the AMD GPU.
+
+To find the architecture, use
+```bash
+rocminfo | grep 'Name: *gfx.*'
+```
+
+which should show something like
+```bash
+  Name:                    gfx1030
+```
+where `gfx` followed by four digits the GPU's the architecture.
+
 See the [`dpctl` documentation](https://intelpython.github.io/dpctl/latest/beginners_guides/installation.html#building-for-custom-sycl-targets) for more information.
 
 ## Building extension manually
@@ -82,6 +101,18 @@ VERBOSE=1 CXX=icpx Dpctl_ROOT=$(python -m dpctl --cmakedir) pip install -e \
     -Ccmake.args="-DTARGET_CUDA=ON"
 ```
 
+To build the extension to offload to AMD GPUs, we need to set ``TARGET_HIP`` cmake variable. ``TARGET_CUDA`` is boolean, but to build
+for AMD, the GPU architecture must be provided, i.e.:
+
+```bash
+VERBOSE=1 CXX=icpx Dpctl_ROOT=$(python -m dpctl --cmakedir) pip install -e \
+    scikit_build_core_sycl_python_extension --no-deps --no-build-isolation --verbose \
+    -Ccmake.args="-DTARGET_HIP=<ARCH>"
+```
+
+where `<ARCH>` is the GPU architecture. See [dpctl NVidia and AMD build instructions](#build-dpctl-for-nvidia-or-amd) for an example of
+finding the architecture.
+
 ## Build and install extension with meson-python
 
 If requirements are not installed, install requirements.
@@ -115,3 +146,14 @@ using `setup-args` [setup-args](https://meson-python.readthedocs.io/en/latest/ho
 VERBOSE=1 CXX=icpx pip install -e meson_sycl_python_extension --no-deps --no-build-isolation --verbose \
     -Csetup-args="-Dtarget-cuda=true"
 ```
+
+To build the extension to offload to AMD GPUs, we need to set ``target-hip`` cmake variable. ``target-cuda`` is boolean, but to build
+for AMD, the GPU architecture must be provided, i.e.:
+
+```bash
+VERBOSE=1 CXX=icpx pip install -e meson_sycl_python_extension --no-deps --no-build-isolation --verbose \
+    -Csetup-args="-Dtarget-hip=<ARCH>"
+```
+
+where `<ARCH>` is the GPU architecture. See [dpctl NVidia and AMD build instructions](#build-dpctl-for-nvidia-or-amd) for an example of
+finding the architecture.

--- a/steps/sycl_python_extension/meson_sycl_python_extension/meson.build
+++ b/steps/sycl_python_extension/meson_sycl_python_extension/meson.build
@@ -26,7 +26,7 @@ if should_target_cuda
   sycl_targets = 'nvptx64-nvidia-cuda,spir64-unknown-unknown'
 endif
 if targeted_hip_arch != ''
-  if sycl_targets
+  if sycl_targets != ''
     sycl_targets = 'amdgcn-amd-amdhsa,' + sycl_targets
   else
     sycl_targets = 'amdgcn-amd-amdhsa,spir64-unknown-unknown'

--- a/steps/sycl_python_extension/meson_sycl_python_extension/meson.build
+++ b/steps/sycl_python_extension/meson_sycl_python_extension/meson.build
@@ -22,6 +22,7 @@ endif
 
 should_target_cuda = get_option('target-cuda')
 targeted_hip_arch = get_option('target-hip')
+sycl_targets = ''
 if should_target_cuda
   sycl_targets = 'nvptx64-nvidia-cuda,spir64-unknown-unknown'
 endif

--- a/steps/sycl_python_extension/meson_sycl_python_extension/meson.build
+++ b/steps/sycl_python_extension/meson_sycl_python_extension/meson.build
@@ -21,9 +21,20 @@ if not result
 endif
 
 should_target_cuda = get_option('target-cuda')
+targeted_hip_arch = get_option('target-hip')
 if should_target_cuda
-    sycl_compile_opts = ['-fsycl', '-fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown']
-    sycl_link_opts = ['-fsycl', '-fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown']
+    sycl_targets = 'nvptx64-nvidia-cuda,spir64-unknown-unknown'
+if targeted_hip_arch
+    if sycl_targets
+      sycl_targets = 'amdgcn-amd-amdhsa,' + sycl_targets
+    else
+      sycl_targets = 'amdgcn-amd-amdhsa,spir64-unknown-unknown'
+if sycl_targets
+  sycl_compile_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
+  sycl_link_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
+  if targeted_hip_arch
+    sycl_compile_opts = sycl_compile_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
+    sycl_link_opts = sycl_link_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
 else
     sycl_compile_opts = '-fsycl'
     sycl_link_opts = '-fsycl'

--- a/steps/sycl_python_extension/meson_sycl_python_extension/meson.build
+++ b/steps/sycl_python_extension/meson_sycl_python_extension/meson.build
@@ -24,17 +24,18 @@ should_target_cuda = get_option('target-cuda')
 targeted_hip_arch = get_option('target-hip')
 if should_target_cuda
     sycl_targets = 'nvptx64-nvidia-cuda,spir64-unknown-unknown'
-if targeted_hip_arch
+if targeted_hip_arch != ''
     if sycl_targets
-      sycl_targets = 'amdgcn-amd-amdhsa,' + sycl_targets
+        sycl_targets = 'amdgcn-amd-amdhsa,' + sycl_targets
     else
-      sycl_targets = 'amdgcn-amd-amdhsa,spir64-unknown-unknown'
-if sycl_targets
-  sycl_compile_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
-  sycl_link_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
-  if targeted_hip_arch
-    sycl_compile_opts = sycl_compile_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
-    sycl_link_opts = sycl_link_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
+        sycl_targets = 'amdgcn-amd-amdhsa,spir64-unknown-unknown'
+
+if sycl_targets != ''
+    sycl_compile_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
+    sycl_link_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
+    if targeted_hip_arch != ''
+        sycl_compile_opts = sycl_compile_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
+        sycl_link_opts = sycl_link_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
 else
     sycl_compile_opts = '-fsycl'
     sycl_link_opts = '-fsycl'

--- a/steps/sycl_python_extension/meson_sycl_python_extension/meson.build
+++ b/steps/sycl_python_extension/meson_sycl_python_extension/meson.build
@@ -23,19 +23,23 @@ endif
 should_target_cuda = get_option('target-cuda')
 targeted_hip_arch = get_option('target-hip')
 if should_target_cuda
-    sycl_targets = 'nvptx64-nvidia-cuda,spir64-unknown-unknown'
+  sycl_targets = 'nvptx64-nvidia-cuda,spir64-unknown-unknown'
+endif
 if targeted_hip_arch != ''
-    if sycl_targets
-        sycl_targets = 'amdgcn-amd-amdhsa,' + sycl_targets
-    else
-        sycl_targets = 'amdgcn-amd-amdhsa,spir64-unknown-unknown'
+  if sycl_targets
+    sycl_targets = 'amdgcn-amd-amdhsa,' + sycl_targets
+  else
+    sycl_targets = 'amdgcn-amd-amdhsa,spir64-unknown-unknown'
+  endif
+endif
 
 if sycl_targets != ''
-    sycl_compile_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
-    sycl_link_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
-    if targeted_hip_arch != ''
-        sycl_compile_opts = sycl_compile_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
-        sycl_link_opts = sycl_link_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
+  sycl_compile_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
+  sycl_link_opts = ['-fsycl', '-fsycl-targets=' + sycl_targets]
+  if targeted_hip_arch != ''
+    sycl_compile_opts = sycl_compile_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
+    sycl_link_opts = sycl_link_opts + ['-Xsycl-target-backend=amdgcn-amd-amdhsa', '--offload-arch=' + targeted_hip_arch]
+  endif
 else
     sycl_compile_opts = '-fsycl'
     sycl_link_opts = '-fsycl'

--- a/steps/sycl_python_extension/meson_sycl_python_extension/meson.options
+++ b/steps/sycl_python_extension/meson_sycl_python_extension/meson.options
@@ -7,7 +7,7 @@ option(
 
 option(
     'target-hip',
-    type: 'str',
+    type: 'string',
     value: '',
     description: 'Whether to compile for a given HIP architecture'
 )

--- a/steps/sycl_python_extension/meson_sycl_python_extension/meson.options
+++ b/steps/sycl_python_extension/meson_sycl_python_extension/meson.options
@@ -4,3 +4,10 @@ option(
     value: false, 
     description: 'Whether to compile for SYCL target NVPTX64'
 )
+
+option(
+    'target-hip',
+    type: 'str',
+    value: '',
+    description: 'Whether to compile for a given HIP architecture'
+)

--- a/steps/sycl_python_extension/scikit_build_core_sycl_python_extension/CMakeLists.txt
+++ b/steps/sycl_python_extension/scikit_build_core_sycl_python_extension/CMakeLists.txt
@@ -5,7 +5,14 @@ project(${SKBUILD_PROJECT_NAME}
     LANGUAGES CXX
     DESCRIPTION "A sample kernel density estimation pybind11 extension for dpctl"
 )
-option(TARGET_CUDA "Whether to build SYCL target NVPTX64 in addition to default SPIR64 SYCL target" OFF)
+
+option(TARGET_CUDA "Whether to additionally target NVPTX64" OFF)
+
+set(TARGET_HIP
+    ""
+    CACHE STRING
+    "Whether to additionally target a user-specified HIP architecture"
+)
 
 find_package(IntelSYCL REQUIRED)
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
@@ -38,9 +45,33 @@ target_compile_options(${py_module_name} PRIVATE -O3 -fno-approx-func -fno-fast-
 target_include_directories(${py_module_name} PRIVATE ${Dpctl_INCLUDE_DIRS})
 target_include_directories(${py_module_name} PRIVATE ${Dpctl_TENSOR_INCLUDE_DIR})
 
+set(_sycl_targets)
+set(_hip_targets)
 if (${TARGET_CUDA})
-    target_compile_options(${py_module_name} PRIVATE -fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown)
-    target_link_options(${py_module_name} PRIVATE -fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown)
+    set(_sycl_targets "nvptx64-nvidia-cuda,spir64-unknown-unknown")
+endif()
+if (NOT "x${TARGET_HIP}" STREQUAL "x")
+    set(_hip_targets ${TARGET_HIP})
+    if(_sycl_targets)
+        set(_sycl_targets "amdgcn-amd-amdhsa,${_dpctl_sycl_targets}")
+    else()
+        set(_sycl_targets "amdgcn-amd-amdhsa,spir64-unknown-unknown")
+    endif()
+endif()
+
+set(_sycl_target_compile_options)
+set(_sycl_target_link_options)
+
+if (_sycl_targets)
+    message(STATUS "Compiling for -fsycl-targets=${_sycl_targets}")
+    list(APPEND _sycl_target_compile_options -fsycl-targets=${_sycl_targets})
+    list(APPEND _sycl_target_link_options -fsycl-targets=${_sycl_targets})
+    if(_hip_targets)
+        list(APPEND _sycl_target_compile_options -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=${_hip_targets})
+        list(APPEND _sycl_target_link_options -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=${_hip_targets})
+    endif()
+    target_compile_options(${py_module_name} PUBLIC ${_sycl_target_compile_options})
+    target_link_options(${py_module_name} PUBLIC ${_sycl_target_link_options})
 endif()
 
 install(TARGETS ${py_module_name} DESTINATION ${SKBUILD_PROJECT_NAME})


### PR DESCRIPTION
This PR adds necessary CMake and Meson options for building extensions targeting HIP architectures, as well as updates instructions