### PR TITLE
Add missing include directory to examples/include to resolve issue 1

### DIFF
--- a/steps/mkl_interface/building.md
+++ b/steps/mkl_interface/building.md
@@ -68,6 +68,7 @@ cd examples/lapack/run_time_dispatching/
 icpx -fsycl getrs_usm.cpp                                     \
     -fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown \
     -I${MKL_INTERFACE_ROOT}/include                           \
+    -I${MKL_INTERFACE_ROOT}/../examples/include               \
     -L${MKL_INTERFACE_ROOT}/lib -lonemkl                      \
     -Wl,-rpath,${MKL_INTERFACE_ROOT}/lib -o run
 ```


### PR DESCRIPTION
Closes gh-1

Adds `-I${MKL_INTERFACE_ROOT}/../examples/include` to the example compilation command.